### PR TITLE
Build properties for 2023.2 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ pluginGroup = rife.idea
 pluginName = RIFE2
 pluginRepositoryUrl = https://github.com/rife2/rife2-idea
 # SemVer format -> https://semver.org
-pluginVersion = 0.5.8
+pluginVersion = 0.5.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 221
-pluginUntilBuild = 231.*
+pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
Noticed that the RIFE2 plugin isn't compatible with the latest release of IntelliJ IDEA 2023.2.
I haven't built an IntelliJ plugin before, so I'm not sure if I covered all the bases here, but wanted to help get the ball rolling at least. My assumption is that we only need a version bump for now, but I could be totally wrong.